### PR TITLE
git-gui: mirror from j6t/git-gui

### DIFF
--- a/.github/workflows/sync-git-gui.yml
+++ b/.github/workflows/sync-git-gui.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  SOURCE_REPOSITORY: prati0100/git-gui
+  SOURCE_REPOSITORY: j6t/git-gui
   TARGET_REPOSITORY: gitgitgadget/git
   TARGET_REF_NAMESPACE: git-gui/
 


### PR DESCRIPTION
As per
https://lore.kernel.org/git/0241021e-0b17-4031-ad9f-8abe8e0c0097@kdbg.org/ Git GUI is now maintained by Johannes Sixt.