### PR TITLE
Use the official GitHub Action to obtain installation access tokens

### DIFF
--- a/.github/workflows/sync-git-gui.yml
+++ b/.github/workflows/sync-git-gui.yml
@@ -25,6 +25,10 @@ jobs:
         id: check
         with:
           script: |
+            const [targetRepoOwner, targetRepoName] = process.env.TARGET_REPOSITORY.split('/')
+            core.setOutput('target-repo-owner', targetRepoOwner)
+            core.setOutput('target-repo-name', targetRepoName)
+
             const sleep = async (milliseconds) => {
               return new Promise(resolve => setTimeout(resolve, milliseconds))
             }
@@ -109,12 +113,13 @@ jobs:
             core.setOutput('to-fetch', [...toFetch].join(' '))
       - name: obtain installation token
         if: steps.check.outputs.refspec != ''
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        uses: actions/create-github-app-token@v1
         id: token
         with:
-          app_id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
-          private_key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-          repository: ${{ env.TARGET_REPOSITORY }}
+          app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+          private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ steps.check.outputs.target-repo-owner }}
+          repositories: ${{ steps.check.outputs.target-repo-name }}
       - name: set authorization header
         if: steps.check.outputs.refspec != ''
         uses: actions/github-script@v7

--- a/.github/workflows/sync-gitster-git.yml
+++ b/.github/workflows/sync-gitster-git.yml
@@ -24,6 +24,10 @@ jobs:
         id: check
         with:
           script: |
+            const [targetRepoOwner, targetRepoName] = process.env.TARGET_REPOSITORY.split('/')
+            core.setOutput('target-repo-owner', targetRepoOwner)
+            core.setOutput('target-repo-name', targetRepoName)
+
             const sleep = async (milliseconds) => {
               return new Promise(resolve => setTimeout(resolve, milliseconds))
             }
@@ -95,12 +99,13 @@ jobs:
             core.setOutput('to-fetch', [...toFetch].join(' '))
       - name: obtain installation token
         if: steps.check.outputs.refspec != ''
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        uses: actions/create-github-app-token@v1
         id: token
         with:
-          app_id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
-          private_key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-          repository: ${{ env.TARGET_REPOSITORY }}
+          app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+          private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ steps.check.outputs.target-repo-owner }}
+          repositories: ${{ steps.check.outputs.target-repo-name }}
       - name: set authorization header
         if: steps.check.outputs.refspec != ''
         uses: actions/github-script@v7

--- a/.github/workflows/sync-ref.yml
+++ b/.github/workflows/sync-ref.yml
@@ -30,6 +30,10 @@ jobs:
         id: check
         with:
           script: |
+            const [targetRepoOwner, targetRepoName] = process.env.TARGET_REPOSITORY.split('/')
+            core.setOutput('target-repo-owner', targetRepoOwner)
+            core.setOutput('target-repo-name', targetRepoName)
+
             const getSHA = async (repository, ref) => {
               if (ref.startsWith('refs/heads/') || ref.startsWith('refs/tags/')) ref = ref.substring(4)
               else throw new Error(`Cannot handle ref '${ref}`)
@@ -60,12 +64,13 @@ jobs:
             core.setOutput('target-sha', targetSHA || '')
       - name: obtain installation token
         if: steps.check.outputs.skip == 'false'
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        uses: actions/create-github-app-token@v1
         id: token
         with:
-          app_id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
-          private_key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-          repository: ${{ env.TARGET_REPOSITORY }}
+          app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+          private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ steps.check.outputs.target-repo-owner }}
+          repositories: ${{ steps.check.outputs.target-repo-name }}
       - name: set authorization header
         if: steps.check.outputs.skip == 'false'
         uses: actions/github-script@v7


### PR DESCRIPTION
This addresses https://github.com/gitgitgadget/gitgitgadget-workflows/issues/5.

I verified that this works as intended by (temporarily) [mirroring Git for Windows' `shears/seen` branch to `gitgitgadget/git`](https://github.com/gitgitgadget/gitgitgadget-workflows/actions/runs/14088477067/job/39458752888) (and I immediately [deleted it](https://github.com/gitgitgadget/git/activity?ref=shears/seen) because it is not needed there).