### PR TITLE
Consume project-specific settings from the `CONFIG` repository variable

### DIFF
--- a/.github/workflows/handle-new-mails.yml
+++ b/.github/workflows/handle-new-mails.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   handle-new-mails:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -35,6 +36,7 @@ jobs:
         repositories: git
     - uses: gitgitgadget/gitgitgadget/handle-new-mails@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/handle-new-mails.yml
+++ b/.github/workflows/handle-new-mails.yml
@@ -18,22 +18,24 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.baseOwner) }}
       id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: git
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.baseOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.testOwner) }}
       id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: dscho
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.testOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: gitgitgadget/gitgitgadget/handle-new-mails@v1
       with:
         config: ${{ vars.CONFIG }}

--- a/.github/workflows/handle-new-mails.yml
+++ b/.github/workflows/handle-new-mails.yml
@@ -14,21 +14,21 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
         owner: gitgitgadget
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: git-git-token
+      id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: git
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: dscho-git-token
+      id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
@@ -37,6 +37,6 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/handle-new-mails@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
-        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
-        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
+        test-repo-token: ${{ steps.test-repo-token.outputs.token }}

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -27,22 +27,24 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.baseOwner) }}
       id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: git
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.baseOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.testOwner) }}
       id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: dscho
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.testOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - name: create a check run
       id: create-check-run
       run: |
@@ -67,9 +69,9 @@ jobs:
         echo "repo=$repo" >> $GITHUB_OUTPUT
 
         export GH_TOKEN="$(case "$repo" in
-          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
-          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.owner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.pr-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.baseOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.testOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"
@@ -97,9 +99,9 @@ jobs:
       if: always() && steps.create-check-run.outputs.check_run_id != ''
       run: |
         export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
-          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
-          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.owner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.pr-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.baseOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.testOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -23,21 +23,21 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
         owner: gitgitgadget
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: git-git-token
+      id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: git
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: dscho-git-token
+      id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
@@ -67,9 +67,9 @@ jobs:
         echo "repo=$repo" >> $GITHUB_OUTPUT
 
         export GH_TOKEN="$(case "$repo" in
-          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
-          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
+          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"
@@ -86,9 +86,9 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/handle-pr-comment@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
-        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
-        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
+        test-repo-token: ${{ steps.test-repo-token.outputs.token }}
         smtp-host: smtp.gmail.com
         smtp-user: gitgitgadget@gmail.com
         smtp-pass: "${{ secrets.GITGITGADGET_SMTP_PASS }}"
@@ -97,9 +97,9 @@ jobs:
       if: always() && steps.create-check-run.outputs.check_run_id != ''
       run: |
         export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
-          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
-          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
+          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -91,8 +91,8 @@ jobs:
         pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
         upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
         test-repo-token: ${{ steps.test-repo-token.outputs.token }}
-        smtp-host: smtp.gmail.com
-        smtp-user: gitgitgadget@gmail.com
+        smtp-host: '${{ fromJSON(vars.CONFIG).mail.smtpHost }}'
+        smtp-user: '${{ fromJSON(vars.CONFIG).mail.smtpUser }}'
         smtp-pass: "${{ secrets.GITGITGADGET_SMTP_PASS }}"
         pr-comment-url: ${{ env.PR_COMMENT_URL }}
     - name: update the check run

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   handle-pr-comment:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -84,6 +85,7 @@ jobs:
         echo "check_run_id=$check_run_id" >> $GITHUB_OUTPUT
     - uses: gitgitgadget/gitgitgadget/handle-pr-comment@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -27,22 +27,24 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.baseOwner) }}
       id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: git
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.baseOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.testOwner) }}
       id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: dscho
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.testOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - name: create a check run
       id: create-check-run
       run: |
@@ -65,9 +67,9 @@ jobs:
         echo "repo=$repo" >> $GITHUB_OUTPUT
 
         export GH_TOKEN="$(case "$repo" in
-          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
-          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.owner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.pr-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.baseOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.testOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"
@@ -92,9 +94,9 @@ jobs:
       if: always() && steps.create-check-run.outputs.check_run_id != ''
       run: |
         export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
-          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
-          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.owner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.pr-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.baseOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.testOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -23,21 +23,21 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
         owner: gitgitgadget
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: git-git-token
+      id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: git
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: dscho-git-token
+      id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
@@ -65,9 +65,9 @@ jobs:
         echo "repo=$repo" >> $GITHUB_OUTPUT
 
         export GH_TOKEN="$(case "$repo" in
-          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
-          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
+          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"
@@ -84,17 +84,17 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/handle-pr-push@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
-        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
-        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
+        test-repo-token: ${{ steps.test-repo-token.outputs.token }}
         pr-url: ${{ env.PR_URL }}
     - name: update the check run
       if: always() && steps.create-check-run.outputs.check_run_id != ''
       run: |
         export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
-          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
-          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
+          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   handle-pr-push:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -82,6 +83,7 @@ jobs:
         echo "check_run_id=$check_run_id" >> $GITHUB_OUTPUT
     - uses: gitgitgadget/gitgitgadget/handle-pr-push@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/sync-mailing-list-mirror.yml
+++ b/.github/workflows/sync-mailing-list-mirror.yml
@@ -6,9 +6,9 @@ on:
     - cron:  "*/5 * * * *"
 
 env:
-  LORE_EPOCH: 1 # also adjust SOURCE_REPOSITORY
-  SOURCE_REPOSITORY: https://lore.kernel.org/git/1 # LORE_EPOCH
-  TARGET_GITHUB_REPOSITORY: gitgitgadget/git-mailing-list-mirror
+  MIRROR_REF: ${{ fromJSON(vars.CONFIG).mailrepo.mirrorRef }}
+  SOURCE_REPOSITORY: ${{ fromJSON(vars.CONFIG).mailrepo.url }}${{ fromJSON(vars.CONFIG).mailrepo.public_inbox_epoch }}
+  TARGET_GITHUB_REPOSITORY: ${{ fromJSON(vars.CONFIG).mailrepo.owner }}/${{ fromJSON(vars.CONFIG).mailrepo.name }}
 
 concurrency:
   group: sync-mailing-list-mirror
@@ -27,16 +27,16 @@ jobs:
         echo "org=${TARGET_GITHUB_REPOSITORY%%/*}" >>$GITHUB_OUTPUT &&
         echo "repo=${TARGET_GITHUB_REPOSITORY#*/}" >>$GITHUB_OUTPUT &&
         source="$(git ls-remote "$SOURCE_REPOSITORY" master)" &&
-        target="$(git ls-remote https://github.com/"$TARGET_GITHUB_REPOSITORY" lore-$LORE_EPOCH)" &&
+        target="$(git ls-remote https://github.com/"$TARGET_GITHUB_REPOSITORY" "$MIRROR_REF")" &&
         echo "result=$(test "${source%%	*}" = "${target%%	*}" && echo false || echo true)" >>$GITHUB_OUTPUT
     - name: Partial clone
       if: steps.needs-update.outputs.result == 'true'
       run: |
-        git clone --bare --depth=1 -b lore-$LORE_EPOCH --filter=blob:none https://github.com/$TARGET_GITHUB_REPOSITORY .
+        git clone --bare --depth=1 -b "${MIRROR_REF#refs/heads/}" --filter=blob:none https://github.com/$TARGET_GITHUB_REPOSITORY .
     - name: Update from lore.kernel.org
       if: steps.needs-update.outputs.result == 'true'
       run: |
-        git fetch "$SOURCE_REPOSITORY" refs/heads/master:refs/heads/lore-$LORE_EPOCH
+        git fetch "$SOURCE_REPOSITORY" refs/heads/master:"$MIRROR_REF"
     - name: obtain installation token
       if: steps.needs-update.outputs.result == 'true'
       uses: actions/create-github-app-token@v2
@@ -51,4 +51,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       run: |
-        git push https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$TARGET_GITHUB_REPOSITORY lore-$LORE_EPOCH
+        git push https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$TARGET_GITHUB_REPOSITORY "$MIRROR_REF"

--- a/.github/workflows/sync-upstream-branches.yml
+++ b/.github/workflows/sync-upstream-branches.yml
@@ -16,13 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spec:
-          - sourceRepo: j6t/git-gui
-            targetRepo: gitgitgadget/git
-            targetRefNamespace: git-gui/
-          - sourceRepo: gitster/git
-            targetRepo: gitgitgadget/git
-            sourceRefRegex: "^refs/heads/(maint-\\d|[a-z][a-z]/)"
+        spec: ${{ fromJSON(vars.CONFIG).syncUpstreamBranches }}
 
     steps:
       - name: check which refs need to be synchronized

--- a/.github/workflows/update-mail-to-commit-notes.yml
+++ b/.github/workflows/update-mail-to-commit-notes.yml
@@ -19,8 +19,8 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: gitgitgadget/gitgitgadget/update-mail-to-commit-notes@v1
       with:
         config: ${{ vars.CONFIG }}

--- a/.github/workflows/update-mail-to-commit-notes.yml
+++ b/.github/workflows/update-mail-to-commit-notes.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
@@ -24,4 +24,4 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/update-mail-to-commit-notes@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}

--- a/.github/workflows/update-mail-to-commit-notes.yml
+++ b/.github/workflows/update-mail-to-commit-notes.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   update-mail-to-commit-notes:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -22,4 +23,5 @@ jobs:
         repositories: git
     - uses: gitgitgadget/gitgitgadget/update-mail-to-commit-notes@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -14,21 +14,21 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
         owner: gitgitgadget
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: git-git-token
+      id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: git
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: dscho-git-token
+      id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
@@ -37,6 +37,6 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/update-prs@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
-        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
-        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
+        test-repo-token: ${{ steps.test-repo-token.outputs.token }}

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   update-prs:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -35,6 +36,7 @@ jobs:
         repositories: git
     - uses: gitgitgadget/gitgitgadget/update-prs@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -18,22 +18,24 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.baseOwner) }}
       id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: git
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.baseOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.testOwner) }}
       id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: dscho
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.testOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: gitgitgadget/gitgitgadget/update-prs@v1
       with:
         config: ${{ vars.CONFIG }}


### PR DESCRIPTION
Currently, GitGitGadget supports only PRs for the Git project. However, there was already a ton of work to encapsulate project-specific information via [the `IConfig` interface](https://github.com/gitgitgadget/gitgitgadget/blob/e60dc488eb21f5b67c3418640d26077b47511730/lib/project-config.ts#L11-L54).

Let's move this config to the `gitgitgadget-workflows` repository.

Ideally, we would just add it as a file into the main branch. However, this is a violation of the separation of concerns where the workflows are meant to be generic, yet the config is project-specific. That is, the workflows should be identical in all the forks, but the config absolutely not. The config should be very specific.

Theoretically, we could play games with subdirectories that are named like the forks' organization, or something like that. However, that would create a lot of merge conflicts when synchronizing with upstream, which is a major maintenance headache.

Therefore, the config must be separated from the workflows, and cannot live on the main branch.

One option is to store it in the `CONFIG` repository variable. This offers the convenience of being able to use them directly and GitHub workflow definitions.

A major disadvantage, however, is that repository variables are highly intransparent: Only administrators can view and modify them. There is no way to open a pull request to change the config in there. Cross-repository access is finicky (`GITHUB_TOKEN` lacks the permissions...).

An alternative would be to store the config in a dedicated branch, say, `config`, where basically just this config lives, in a file, say, `gitgitgadget-config.json`, that can be viewed by anyone, that can be modified via pull requests, and forked and merged and pulled. Unfortunately, there is no convenient way to use that file in a GitHub workflow definition. For example, when defining a matrix job, the YAML has access to the `vars` but not to any "random blob on a random branch".

So why not have the best of both worlds? Maintain the config in that file on that branch. Add automation to validate it in pull requests and to automatically synchronize it to the repository variable when the branch is pushed.

I already took the liberty of pushing it [to the `gitgitgadget-workflows/gitgitgadget-workflows` repository](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/blob/config/gitgitgadget-config.json). It successfully [validated](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/17485279288) the config and [synchronized](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/actions/runs/17485279312) it to [the `CONFIG` repository variable](https://github.com/gitgitgadget-workflows/gitgitgadget-workflows/settings/variables/actions/CONFIG).

There is currently a temporary commit at the tip of the `config` branch, to use the `validate-config` GitHub Action from my fork of `gitgitgadget/gitgitgadget` (because that Action has not yet been offered via a PR). I will remove this commit and force-push that branch once that Action is merged.

With these prerequisites, we can stop hard-coding a _lot_ of project-specific settings in this here repository, and instead consume the settings from `vars.CONFIG`.

This PR is stacked on top of #12, and also requires https://github.com/gitgitgadget/gitgitgadget/pull/1991 to be merged first.