### PR TITLE
Allow initializing the Git notes required by GitGitGadget

### DIFF
--- a/.github/workflows/handle-new-mails.yml
+++ b/.github/workflows/handle-new-mails.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   handle-new-mails:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -35,6 +36,7 @@ jobs:
         repositories: git
     - uses: gitgitgadget/gitgitgadget/handle-new-mails@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/handle-new-mails.yml
+++ b/.github/workflows/handle-new-mails.yml
@@ -18,22 +18,24 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.baseOwner) }}
       id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: git
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.baseOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.testOwner) }}
       id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: dscho
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.testOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: gitgitgadget/gitgitgadget/handle-new-mails@v1
       with:
         config: ${{ vars.CONFIG }}

--- a/.github/workflows/handle-new-mails.yml
+++ b/.github/workflows/handle-new-mails.yml
@@ -14,21 +14,21 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
         owner: gitgitgadget
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: git-git-token
+      id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: git
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: dscho-git-token
+      id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
@@ -37,6 +37,6 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/handle-new-mails@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
-        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
-        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
+        test-repo-token: ${{ steps.test-repo-token.outputs.token }}

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -27,22 +27,24 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.baseOwner) }}
       id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: git
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.baseOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.testOwner) }}
       id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: dscho
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.testOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - name: create a check run
       id: create-check-run
       run: |
@@ -67,9 +69,9 @@ jobs:
         echo "repo=$repo" >> $GITHUB_OUTPUT
 
         export GH_TOKEN="$(case "$repo" in
-          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
-          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.owner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.pr-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.baseOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.testOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"
@@ -97,9 +99,9 @@ jobs:
       if: always() && steps.create-check-run.outputs.check_run_id != ''
       run: |
         export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
-          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
-          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.owner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.pr-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.baseOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.testOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -23,21 +23,21 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
         owner: gitgitgadget
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: git-git-token
+      id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: git
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: dscho-git-token
+      id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
@@ -67,9 +67,9 @@ jobs:
         echo "repo=$repo" >> $GITHUB_OUTPUT
 
         export GH_TOKEN="$(case "$repo" in
-          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
-          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
+          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"
@@ -86,9 +86,9 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/handle-pr-comment@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
-        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
-        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
+        test-repo-token: ${{ steps.test-repo-token.outputs.token }}
         smtp-host: smtp.gmail.com
         smtp-user: gitgitgadget@gmail.com
         smtp-pass: "${{ secrets.GITGITGADGET_SMTP_PASS }}"
@@ -97,9 +97,9 @@ jobs:
       if: always() && steps.create-check-run.outputs.check_run_id != ''
       run: |
         export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
-          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
-          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
+          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -91,8 +91,8 @@ jobs:
         pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
         upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
         test-repo-token: ${{ steps.test-repo-token.outputs.token }}
-        smtp-host: smtp.gmail.com
-        smtp-user: gitgitgadget@gmail.com
+        smtp-host: '${{ fromJSON(vars.CONFIG).mail.smtpHost }}'
+        smtp-user: '${{ fromJSON(vars.CONFIG).mail.smtpUser }}'
         smtp-pass: "${{ secrets.GITGITGADGET_SMTP_PASS }}"
         pr-comment-url: ${{ env.PR_COMMENT_URL }}
     - name: update the check run

--- a/.github/workflows/handle-pr-comment.yml
+++ b/.github/workflows/handle-pr-comment.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   handle-pr-comment:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -84,6 +85,7 @@ jobs:
         echo "check_run_id=$check_run_id" >> $GITHUB_OUTPUT
     - uses: gitgitgadget/gitgitgadget/handle-pr-comment@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -27,22 +27,24 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.baseOwner) }}
       id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: git
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.baseOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.testOwner) }}
       id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: dscho
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.testOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - name: create a check run
       id: create-check-run
       run: |
@@ -65,9 +67,9 @@ jobs:
         echo "repo=$repo" >> $GITHUB_OUTPUT
 
         export GH_TOKEN="$(case "$repo" in
-          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
-          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.owner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.pr-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.baseOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.testOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"
@@ -92,9 +94,9 @@ jobs:
       if: always() && steps.create-check-run.outputs.check_run_id != ''
       run: |
         export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
-          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
-          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.owner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.pr-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.baseOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          '${{ fromJSON(vars.CONFIG).repo.testOwner }}/${{ fromJSON(vars.CONFIG).repo.name }}') echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -23,21 +23,21 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
         owner: gitgitgadget
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: git-git-token
+      id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: git
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: dscho-git-token
+      id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
@@ -65,9 +65,9 @@ jobs:
         echo "repo=$repo" >> $GITHUB_OUTPUT
 
         export GH_TOKEN="$(case "$repo" in
-          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
-          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
+          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"
@@ -84,17 +84,17 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/handle-pr-push@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
-        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
-        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
+        test-repo-token: ${{ steps.test-repo-token.outputs.token }}
         pr-url: ${{ env.PR_URL }}
     - name: update the check run
       if: always() && steps.create-check-run.outputs.check_run_id != ''
       run: |
         export GH_TOKEN="$(case "${{ steps.create-check-run.outputs.repo }}" in
-          gitgitgadget/git) echo "${{ steps.gitgitgadget-git-token.outputs.token }}";;
-          git/git) echo "${{ steps.git-git-token.outputs.token }}";;
-          dscho/git) echo "${{ steps.dscho-git-token.outputs.token }}";;
+          gitgitgadget/git) echo "${{ steps.pr-repo-token.outputs.token }}";;
+          git/git) echo "${{ steps.upstream-repo-token.outputs.token }}";;
+          dscho/git) echo "${{ steps.test-repo-token.outputs.token }}";;
           *) echo "${{ secrets.GITHUB_TOKEN }}";;
           esac
         )"

--- a/.github/workflows/handle-pr-push.yml
+++ b/.github/workflows/handle-pr-push.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   handle-pr-push:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -82,6 +83,7 @@ jobs:
         echo "check_run_id=$check_run_id" >> $GITHUB_OUTPUT
     - uses: gitgitgadget/gitgitgadget/handle-pr-push@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/initialize-git-notes.yml
+++ b/.github/workflows/initialize-git-notes.yml
@@ -1,0 +1,25 @@
+name: Initialize Git notes
+
+# This workflow is expected to be triggered manually, exactly once, when
+# GitGitGadget is first used with a new `pr-repo`.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  initialize-git-notes:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/create-github-app-token@v1
+      id: pr-repo-token
+      with:
+        app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
+        private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
+    - uses: gitgitgadget/gitgitgadget/initialize-git-notes@v1
+      with:
+        config: ${{ vars.CONFIG }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        initial-user: ${{ github.actor }}

--- a/.github/workflows/sync-mailing-list-mirror.yml
+++ b/.github/workflows/sync-mailing-list-mirror.yml
@@ -6,9 +6,9 @@ on:
     - cron:  "*/5 * * * *"
 
 env:
-  LORE_EPOCH: 1 # also adjust SOURCE_REPOSITORY
-  SOURCE_REPOSITORY: https://lore.kernel.org/git/1 # LORE_EPOCH
-  TARGET_GITHUB_REPOSITORY: gitgitgadget/git-mailing-list-mirror
+  MIRROR_REF: ${{ fromJSON(vars.CONFIG).mailrepo.mirrorRef }}
+  SOURCE_REPOSITORY: ${{ fromJSON(vars.CONFIG).mailrepo.url }}${{ fromJSON(vars.CONFIG).mailrepo.public_inbox_epoch }}
+  TARGET_GITHUB_REPOSITORY: ${{ fromJSON(vars.CONFIG).mailrepo.owner }}/${{ fromJSON(vars.CONFIG).mailrepo.name }}
 
 concurrency:
   group: sync-mailing-list-mirror
@@ -27,16 +27,16 @@ jobs:
         echo "org=${TARGET_GITHUB_REPOSITORY%%/*}" >>$GITHUB_OUTPUT &&
         echo "repo=${TARGET_GITHUB_REPOSITORY#*/}" >>$GITHUB_OUTPUT &&
         source="$(git ls-remote "$SOURCE_REPOSITORY" master)" &&
-        target="$(git ls-remote https://github.com/"$TARGET_GITHUB_REPOSITORY" lore-$LORE_EPOCH)" &&
+        target="$(git ls-remote https://github.com/"$TARGET_GITHUB_REPOSITORY" "$MIRROR_REF")" &&
         echo "result=$(test "${source%%	*}" = "${target%%	*}" && echo false || echo true)" >>$GITHUB_OUTPUT
     - name: Partial clone
       if: steps.needs-update.outputs.result == 'true'
       run: |
-        git clone --bare --depth=1 -b lore-$LORE_EPOCH --filter=blob:none https://github.com/$TARGET_GITHUB_REPOSITORY .
+        git clone --bare --depth=1 -b "${MIRROR_REF#refs/heads/}" --filter=blob:none https://github.com/$TARGET_GITHUB_REPOSITORY .
     - name: Update from lore.kernel.org
       if: steps.needs-update.outputs.result == 'true'
       run: |
-        git fetch "$SOURCE_REPOSITORY" refs/heads/master:refs/heads/lore-$LORE_EPOCH
+        git fetch "$SOURCE_REPOSITORY" refs/heads/master:"$MIRROR_REF"
     - name: obtain installation token
       if: steps.needs-update.outputs.result == 'true'
       uses: actions/create-github-app-token@v2
@@ -51,4 +51,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       run: |
-        git push https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$TARGET_GITHUB_REPOSITORY lore-$LORE_EPOCH
+        git push https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$TARGET_GITHUB_REPOSITORY "$MIRROR_REF"

--- a/.github/workflows/sync-upstream-branches.yml
+++ b/.github/workflows/sync-upstream-branches.yml
@@ -16,13 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spec:
-          - sourceRepo: j6t/git-gui
-            targetRepo: gitgitgadget/git
-            targetRefNamespace: git-gui/
-          - sourceRepo: gitster/git
-            targetRepo: gitgitgadget/git
-            sourceRefRegex: "^refs/heads/(maint-\\d|[a-z][a-z]/)"
+        spec: ${{ fromJSON(vars.CONFIG).syncUpstreamBranches }}
 
     steps:
       - name: check which refs need to be synchronized

--- a/.github/workflows/update-mail-to-commit-notes.yml
+++ b/.github/workflows/update-mail-to-commit-notes.yml
@@ -19,8 +19,8 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: gitgitgadget/gitgitgadget/update-mail-to-commit-notes@v1
       with:
         config: ${{ vars.CONFIG }}

--- a/.github/workflows/update-mail-to-commit-notes.yml
+++ b/.github/workflows/update-mail-to-commit-notes.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
@@ -24,4 +24,4 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/update-mail-to-commit-notes@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}

--- a/.github/workflows/update-mail-to-commit-notes.yml
+++ b/.github/workflows/update-mail-to-commit-notes.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   update-mail-to-commit-notes:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -22,4 +23,5 @@ jobs:
         repositories: git
     - uses: gitgitgadget/gitgitgadget/update-mail-to-commit-notes@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -14,21 +14,21 @@ jobs:
 
     steps:
     - uses: actions/create-github-app-token@v1
-      id: gitgitgadget-git-token
+      id: pr-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
         owner: gitgitgadget
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: git-git-token
+      id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
         owner: git
         repositories: git
     - uses: actions/create-github-app-token@v1
-      id: dscho-git-token
+      id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
@@ -37,6 +37,6 @@ jobs:
     - uses: gitgitgadget/gitgitgadget/update-prs@v1
       with:
         config: ${{ vars.CONFIG }}
-        pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
-        upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
-        test-repo-token: ${{ steps.dscho-git-token.outputs.token }}
+        pr-repo-token: ${{ steps.pr-repo-token.outputs.token }}
+        upstream-repo-token: ${{ steps.upstream-repo-token.outputs.token }}
+        test-repo-token: ${{ steps.test-repo-token.outputs.token }}

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   update-prs:
     runs-on: ubuntu-latest
+    if: vars.CONFIG != ''
 
     steps:
     - uses: actions/create-github-app-token@v1
@@ -35,6 +36,7 @@ jobs:
         repositories: git
     - uses: gitgitgadget/gitgitgadget/update-prs@v1
       with:
+        config: ${{ vars.CONFIG }}
         pr-repo-token: ${{ steps.gitgitgadget-git-token.outputs.token }}
         upstream-repo-token: ${{ steps.git-git-token.outputs.token }}
         test-repo-token: ${{ steps.dscho-git-token.outputs.token }}

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -18,22 +18,24 @@ jobs:
       with:
         app-id: ${{ secrets.GITGITGADGET_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GITHUB_APP_PRIVATE_KEY }}
-        owner: gitgitgadget
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.owner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.baseOwner) }}
       id: upstream-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: git
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.baseOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: actions/create-github-app-token@v1
+      if: ${{ contains(fromJSON(vars.CONFIG).repo.owners, fromJSON(vars.CONFIG).repo.testOwner) }}
       id: test-repo-token
       with:
         app-id: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_ID }}
         private-key: ${{ secrets.GITGITGADGET_GIT_GITHUB_APP_PRIVATE_KEY }}
-        owner: dscho
-        repositories: git
+        owner: ${{ fromJSON(vars.CONFIG).repo.testOwner }}
+        repositories: ${{ fromJSON(vars.CONFIG).repo.name }}
     - uses: gitgitgadget/gitgitgadget/update-prs@v1
       with:
         config: ${{ vars.CONFIG }}


### PR DESCRIPTION
To support projects other than Git, the idea is to:

1. fork the upstream repository (`upstream-repo`) into a new org where PRs can be handled by GitGitGadget (`pr-repo`)
2. mirror the upstream mailing list as a [`public-inbox`](https://public-inbox.org/README.html) repository (if the upstream project does not maintain one themselves, this will have to be maintained in addition to the GitGitGadget instance)
3. fork `gitgitgadget-workflows` into the same, new org
4. configure the project-specific settings via the `CONFIG` repository variable (using [the original project settings](https://github.com/gitgitgadget/gitgitgadget-github-app/pull/7/commits/a1a0dde38f3986cfc7799c5e361def44e6c4bdd7#diff-f3f15703833b400f8c5cf9cc35b7d5fc498ea55a13d2e5ee806c9c0a24d05b9e) as template)
5. initialize the GitGitGadget state (by running the workflow added in this here PR)
6. fork `gitgitgadget-github-app` into the same, new org
7. create a new Azure Function
8. deploy the `gitgitgadget-github-app` fork to that Azure Function
9. register a new GitHub App with that Azure Function's URL as webhook event receiver
10. for technical reasons, deploy the Azure Function a second time

I went through these motions, targeting the Cygwin project, and successfully [`/submit`](https://github.com/cygwingitgadget/cygwin/pull/1#issuecomment-3244961753)ed the first patch that way.

This PR is stacked on top of #13 and requires https://github.com/gitgitgadget/gitgitgadget/pull/1995 to be merged first.