### PR TITLE
Fix keepalive in forks

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -21,6 +21,7 @@ jobs:
         id: merge
         if: github.event.repository.fork == true
         run: |
+          git fetch --unshallow origin &&
           git fetch https://github.com/gitgitgadget/gitgitgadget-workflows HEAD &&
           if test 0 = $(git rev-list --count HEAD..FETCH_HEAD)
           then

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -33,7 +33,8 @@ jobs:
         id: commit
         if: steps.merge.outputs.result != 'merged'
         run: |
-          if test 0 -lt $(git rev-list --count --since=3.weeks.ago HEAD)
+          if test workflow_dispatch != '${{ github.event_name }}' &&
+            test 0 -lt $(git rev-list --count --since=3.weeks.ago HEAD)
           then
             echo "::notice::No need to keep alive, there were commits in the last three weeks"
             echo "result=skip-push" >>$GITHUB_OUTPUT


### PR DESCRIPTION
In the `cygwingitgadget` fork, which I use as a test-bed for developing the modifications required to let GitGitGadget support projects other than Git, a scheduled run of the `keepalive` workflow [failed](https://github.com/cygwingitgadget/gitgitgadget-workflows/actions/runs/17443966045).

The reason is that it needs to determine the merge base between upstream and downstream tips, and that requires non-shallow commit histories. Let's ensure that.

While at it, also fix the design wart that the `keepalive` workflow, when triggered _manually_, would _still_ not produce any commit if the latest change is younger than 3 weeks. I mean, if it is triggered manually, there usually is a need for that, so let's stop the workflow from trying to be smarter than its human handler.